### PR TITLE
fix(XlfParser): read files in binary mode to avoid encoding errors

### DIFF
--- a/xlf_merge/XlfParser.py
+++ b/xlf_merge/XlfParser.py
@@ -12,7 +12,7 @@ class XlfParser:
         self.nsmap = nsmap
 
     @staticmethod
-    def from_xml(xls_content: str) -> 'XlfParser':
+    def from_xml(xls_content: str | bytes) -> 'XlfParser':
         root = XlfParser.parse_xml(xls_content)
 
         nsmap = root.nsmap
@@ -83,7 +83,7 @@ class XlfParser:
 
         root.append(file)
 
-        xml = XlfParser.generate_xml(root)
+        xml: bytes = XlfParser.generate_xml(root)
 
         return XlfParser(trans_units, XlfParser.parse_xml(xml), nsmap)
 
@@ -100,7 +100,7 @@ class XlfParser:
             else:
                 content_tag.append(elem)
 
-    def to_xml(self) -> str:
+    def to_xml(self) -> bytes:
         file = self.root.find('file', self.nsmap)
         body = file.find('body', self.nsmap)
         body.clear()
@@ -133,11 +133,13 @@ class XlfParser:
         return XlfParser.generate_xml(self.root)
 
     @staticmethod
-    def parse_xml(xml: str) -> etree.Element:
+    def parse_xml(xml: str | bytes) -> etree.Element:
         parser = etree.XMLParser(recover=True, remove_blank_text=True)
-        el = etree.ElementTree(etree.fromstring(xml.encode('UTF-8'), parser))
+        if not isinstance(xml, bytes):
+            xml = xml.encode('UTF-8')
+        el = etree.ElementTree(etree.fromstring(xml, parser))
         return el.getroot()
 
     @staticmethod
-    def generate_xml(root: etree.Element) -> str:
-        return etree.tostring(root, encoding='utf8', method='xml', pretty_print=True, xml_declaration=True).decode('UTF-8')
+    def generate_xml(root: etree.Element) -> bytes:
+        return etree.tostring(root, encoding='utf8', method='xml', pretty_print=True, xml_declaration=True)

--- a/xlf_merge/bin/xlf_merge.py
+++ b/xlf_merge/bin/xlf_merge.py
@@ -77,11 +77,11 @@ def command(func):
 @command
 def merge() -> None:
 
-    with open(OPTIONS['<from_file>'], 'r') as from_file_handle:
-        from_file = from_file_handle.read()
+    with open(OPTIONS['<from_file>'], 'rb') as from_file_handle:
+        from_file: bytes = from_file_handle.read()
 
-    with open(OPTIONS['<with_file>'], 'r') as with_file_handle:
-        with_file = with_file_handle.read()
+    with open(OPTIONS['<with_file>'], 'rb') as with_file_handle:
+        with_file: bytes = with_file_handle.read()
 
     from_file_xlf_parser = XlfParser.from_xml(from_file)
     with_file_xlf_parser = XlfParser.from_xml(with_file)
@@ -114,7 +114,7 @@ def merge() -> None:
     final_xlf_parser = XlfParser.from_trans_units(with_file_trans_units)
     pretty_print_output = final_xlf_parser.to_xml()
 
-    with open(OPTIONS['<output_file>'], 'w') as output_file_handle:
+    with open(OPTIONS['<output_file>'], 'wb') as output_file_handle:
         output_file_handle.write(pretty_print_output)
 
 


### PR DESCRIPTION
The tool does not seem to read the encoding declared in the XML file nor does it not default to UTF-8, which is standard for XML.

Instead it uses whatever encoding is default for the OS, like CP1250 on Windows, and sometimes fails with the error:

    UnicodeDecodeError: 'charmap' codec can't decode byte 0x81 in position 63964: character maps to <undefined>       
    error Command failed with exit code 1

Surprisingly, in XlfParser class, it re-encodes the misdecoded string as UTF-8.

I guess it would be better to just read it in binary mode and let the XML parser deal with the charset detection.