### PR TITLE
More clean XML output

### DIFF
--- a/xlf_merge/XlfParser.py
+++ b/xlf_merge/XlfParser.py
@@ -1,5 +1,8 @@
 from lxml import etree, html
+import re
 from typing import List
+
+re_xml_open_close = re.compile(rb'(?:^<[^>]+>)|(?:</[^>]+>$)')
 
 
 class XlfParser:
@@ -14,8 +17,8 @@ class XlfParser:
     @staticmethod
     def from_xml(xls_content: str | bytes) -> 'XlfParser':
         root = XlfParser.parse_xml(xls_content)
-
         nsmap = root.nsmap
+
         file = root.find('file', nsmap)
         body = file.find('body', nsmap)
         trans_units = []
@@ -23,12 +26,10 @@ class XlfParser:
         for trans_units_element in trans_units_elements:
 
             source = trans_units_element.find('source', nsmap)
-            source_text_first = source.text if source.text else ''
-            source_text = source_text_first + b''.join(etree.tostring(e) for e in source).decode('UTF-8')
+            source_text = re_xml_open_close.sub(b'', etree.tostring(source))
             target = trans_units_element.find('target', nsmap)
             if target is not None:
-                target_text_first = target.text if target.text else ''
-                target_text = target_text_first + b''.join(etree.tostring(e) for e in target).decode('UTF-8')
+                target_text = re_xml_open_close.sub(b'', etree.tostring(target))
             else:
                 target_text = ''
 

--- a/xlf_merge/XlfParser.py
+++ b/xlf_merge/XlfParser.py
@@ -68,13 +68,15 @@ class XlfParser:
         return XlfParser(trans_units, root, nsmap)
 
     @staticmethod
-    def from_trans_units(trans_units: List[dict]) -> 'XlfParser':
+    def from_trans_units(trans_units: List[dict], target_language: str | None = None) -> 'XlfParser':
         nsmap = {None: 'urn:oasis:names:tc:xliff:document:1.2'}
         root = etree.Element('xliff', nsmap=nsmap)
         root.set('version', '1.2')
 
         file = etree.Element('file', nsmap=nsmap)
         file.set('source-language', 'en')
+        if target_language:
+            file.set('target-language', target_language)
         file.set('datatype', 'plaintext')
         file.set('original', 'ng2.template')
 
@@ -100,6 +102,9 @@ class XlfParser:
                 content_tag.text = elem
             else:
                 content_tag.append(elem)
+
+    def get_target_language(self):
+        return self.root.find('file', self.nsmap).get('target-language')
 
     def to_xml(self) -> bytes:
         file = self.root.find('file', self.nsmap)

--- a/xlf_merge/bin/xlf_merge.py
+++ b/xlf_merge/bin/xlf_merge.py
@@ -123,7 +123,8 @@ def merge() -> None:
             del with_file_trans_units[found_index]
             with_file_trans_units.insert(found_index, found_trans_unit)
 
-    final_xlf_parser = XlfParser.from_trans_units(with_file_trans_units)
+    target_language = from_file_xlf_parser.get_target_language()
+    final_xlf_parser = XlfParser.from_trans_units(with_file_trans_units, target_language)
     pretty_print_output = final_xlf_parser.to_xml()
 
     with open(OPTIONS['<output_file>'], 'wb') as output_file_handle:


### PR DESCRIPTION
A few more fixes:

1. Fixed --method option to handle id and allow specifying multiple options, to align implementation with README.
2. Fixed source text extraction. Calling `etree.tostring` on every single child has been causing etree to add redundant `xmlns` on element children of `<source>` and `<target>` (namely on `<x>` and `<br/>` tags).
This can be avoided by calling `etree.tostring` on the whole tag and stripping opening and closing tag with regex
(nb. `etree.tostring` always escapes `>`, so there is no need to handle full opening tag syntax; simple regex is enough).
3. Preserve target language attribute if present in the first source file.